### PR TITLE
fixes memory leaks and hanging decoder thread in libavcodec decoder part

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,3 +30,4 @@
 *.exe
 *.out
 *.app
+build

--- a/common/NvV4l2ElementPlane.cpp
+++ b/common/NvV4l2ElementPlane.cpp
@@ -34,6 +34,7 @@
 #include <libv4l2.h>
 #include <sys/mman.h>
 #include <sys/prctl.h>
+#include "nvbuf_utils.h"
 
 #define CHECK_V4L2_RETURN(ret, str)              \
     if (ret < 0) {                               \
@@ -260,6 +261,89 @@ NvV4l2ElementPlane::qBuffer(struct v4l2_buffer &v4l2_buf, NvBuffer * shared_buff
         pthread_cond_broadcast(&plane_cond);
         total_queued_buffers++;
         num_queued_buffers++;
+    }
+    pthread_mutex_unlock(&plane_lock);
+
+    return ret;
+}
+
+int
+NvV4l2ElementPlane::mapOutputBuffers(struct v4l2_buffer &v4l2_buf, int dmabuff_fd)
+{
+    int ret;
+    uint32_t i;
+    NvBufferParams params;
+    pthread_mutex_lock(&plane_lock);
+    unsigned char *data;
+
+    switch (memory_type)
+    {
+        case V4L2_MEMORY_DMABUF:
+            ret = NvBufferGetParams(dmabuff_fd, &params);
+            if(ret < 0)
+            {
+                PLANE_SYS_ERROR_MSG("Error: NvBufferGetParams Failed\n");
+                pthread_mutex_unlock(&plane_lock);
+                return ret;
+            }
+            for (i = 0; i < n_planes; i++)
+            {
+                buffers[v4l2_buf.index]->planes[i].fd = dmabuff_fd;
+                v4l2_buf.m.planes[i].m.fd = buffers[v4l2_buf.index]->planes[i].fd;
+                buffers[v4l2_buf.index]->planes[i].mem_offset = params.offset[i];
+                ret = NvBufferMemMap (dmabuff_fd,i,NvBufferMem_Read_Write, (void **)&data);
+                if (ret < 0)
+                {
+                    is_in_error = 1;
+                    PLANE_SYS_ERROR_MSG("Error while Mapping buffer");
+                    pthread_mutex_unlock(&plane_lock);
+                    return ret;
+                }
+                buffers[v4l2_buf.index]->planes[i].data=data;
+            }
+            break;
+        default:
+            pthread_mutex_unlock(&plane_lock);
+            return -1;
+    }
+    if(ret == 0)
+    {
+        PLANE_DEBUG_MSG("Mapped Nvbuffer to buffers " << v4l2_buf.index);
+    }
+    pthread_mutex_unlock(&plane_lock);
+
+    return ret;
+}
+
+int
+NvV4l2ElementPlane::unmapOutputBuffers(int index, int dmabuff_fd)
+{
+    int ret = 0;
+    uint32_t i;
+    pthread_mutex_lock(&plane_lock);
+
+    switch (memory_type)
+    {
+        case V4L2_MEMORY_DMABUF:
+            for (i = 0; i < n_planes; i++)
+            {
+                ret = NvBufferMemUnMap (dmabuff_fd, i, (void **)&buffers[index]->planes[i].data);
+                if (ret < 0)
+                {
+                    is_in_error = 1;
+                    PLANE_SYS_ERROR_MSG("Error while Unmapping buffer");
+                    pthread_mutex_unlock(&plane_lock);
+                    return ret;
+                }
+            }
+            break;
+        default:
+            pthread_mutex_unlock(&plane_lock);
+            return -1;
+    }
+    if(ret == 0)
+    {
+        PLANE_DEBUG_MSG("Unmapped Nvbuffer to buffers " << index);
     }
     pthread_mutex_unlock(&plane_lock);
 

--- a/common/NvVideoEncoder.cpp
+++ b/common/NvVideoEncoder.cpp
@@ -100,9 +100,10 @@ NvVideoEncoder::setOutputPlaneFormat(uint32_t pixfmt, uint32_t width,
     uint32_t num_bufferplanes;
     NvBuffer::NvBufferPlaneFormat planefmts[MAX_PLANES];
 
-    if (pixfmt != V4L2_PIX_FMT_YUV420M && pixfmt != V4L2_PIX_FMT_YUV444M)
+    if (pixfmt != V4L2_PIX_FMT_YUV420M && pixfmt != V4L2_PIX_FMT_YUV444M &&
+        pixfmt != V4L2_PIX_FMT_P010M)
     {
-        COMP_ERROR_MSG("Only V4L2_PIX_FMT_YUV420M V4L2_PIX_FMT_YUV444M is supported");
+        COMP_ERROR_MSG("Only YUV420M, YUV444M and P010M are supported");
         return -1;
     }
 
@@ -133,6 +134,8 @@ NvVideoEncoder::setCapturePlaneFormat(uint32_t pixfmt, uint32_t width,
     {
         case V4L2_PIX_FMT_H264:
         case V4L2_PIX_FMT_H265:
+        case V4L2_PIX_FMT_VP8:
+        case V4L2_PIX_FMT_VP9:
             capture_plane_pixfmt = pixfmt;
             break;
         default:

--- a/include/NvV4l2ElementPlane.h
+++ b/include/NvV4l2ElementPlane.h
@@ -124,6 +124,25 @@ public:
      */
     int setFormat(struct v4l2_format & format);
 
+    /**
+     * Maps the NvMMBuffer to NvBuffer for V4L2_MEMORY_DMABUF.
+     *
+     * @param[in] v4l2_buf Address of the NvBuffer to which the NvMMBuffer is mapped.
+     * @param[in] dmabuff_fd Index to the field that holds NvMMBuffer attributes.
+     * @return 0 for success, -1 otherwise.
+     */
+
+    int mapOutputBuffers(struct v4l2_buffer &v4l2_buf, int dmabuff_fd);
+
+    /**
+     * Unmaps the NvMMBuffer for V4L2_MEMORY_DMABUF.
+     *
+     * @param[in] index for the current buffer index.
+     * @param[in] dmabuff_fd Index to the field that holds NvMMBuffer attributes.
+     * @return 0 for success, -1 otherwise.
+     */
+
+    int unmapOutputBuffers(int index, int dmabuff_fd);
 
     /**
      * Gets the cropping rectangle for the plane.

--- a/include/v4l2_nv_extensions.h
+++ b/include/v4l2_nv_extensions.h
@@ -49,7 +49,12 @@
  * This file declares NVIDIA V4L2 extensions, controls, and structures.
  *
  */
+/**
+ * Defines V4L2 pixel format for DIVX.
+ */
+#define V4L2_PIX_FMT_DIVX4     v4l2_fourcc('D', 'V', 'X', '4')
 
+#define V4L2_PIX_FMT_DIVX5     v4l2_fourcc('D', 'V', 'X', '5')
 /**
  * Defines V4L2 pixel format for H.265.
  */
@@ -423,6 +428,10 @@ struct v4l2_ctrl_vp8_frame_hdr {
  * Read only. Valid after #V4L2_EVENT_RESOLUTION_CHANGE)
  * - #V4L2_CID_MPEG_VIDEODEC_INPUT_METADATA
  * - #V4L2_CID_MPEG_VIDEODEC_METADATA
+ * - #V4L2_CID_MPEG_VIDEO_BUF_API_TYPE
+ * - #V4L2_CID_MPEG_VIDEO_CUDA_MEM_TYPE
+ * - #V4L2_CID_MPEG_VIDEO_CUDA_GPU_ID
+ * - #V4L2_CID_MPEG_VIDEODEC_DROP_FRAME_INTERVAL
  *
  * ### Supported Events
  * Event                         | Purpose
@@ -600,7 +609,7 @@ struct v4l2_ctrl_vp8_frame_hdr {
  * - #V4L2_CID_VIDEO_CONVERT_FLIP_METHOD
  * - #V4L2_CID_VIDEO_CONVERT_INTERPOLATION_METHOD
  * - #V4L2_CID_VIDEO_CONVERT_TNR_ALGORITHM
- * - #V4L2_CID_VIDEO_CONVERT_YUV_RESCALE
+ * - #V4L2_CID_VIDEO_CONVERT_YUV_RESCALE_METHOD
  *
  * ### Cropping
  * Video converter supports cropping using \c VIDIOC_S_SELECTION IOCTL with type
@@ -1074,6 +1083,63 @@ struct v4l2_ctrl_vp8_frame_hdr {
  */
 #define V4L2_CID_MPEG_VIDEOENC_ENABLE_ALLIFRAME_ENCODE (V4L2_CID_MPEG_BASE+555)
 
+/**
+ * Defines the Control ID to set buf api to be used by decoder/encoder.
+ *
+ * A boolean value should be supplied with this control, default is 0
+ * This has to be called before any other ioctls are used and cannot be changed.
+ *
+ * @attention This control must be set after setting formats on both the planes
+ * and before requesting buffers on either plane.
+ * This is internal ioctl due to be removed later.
+ */
+#define V4L2_CID_MPEG_VIDEO_BUF_API_TYPE (V4L2_CID_MPEG_BASE+556)
+
+/**
+ * Defines the Control ID to set cuda memory type to be used by decoder/encoder.
+ *
+ * This control can be used by the decoder to set the memory type for surfaces.
+ * A value of \c v4l2_cuda_mem_type needs to be set with this control.
+ *
+ * @attention This control must be set after setting formats on both the planes
+ * and before requesting buffers on either plane.
+ */
+#define V4L2_CID_MPEG_VIDEO_CUDA_MEM_TYPE (V4L2_CID_MPEG_BASE+557)
+
+/**
+ * Defines the Control ID to set GPU ID to be used by decoder/encoder.
+ *
+ * An integer value should be supplied with this control.
+ *
+ * @attention This control must be set after setting formats on both the planes
+ * and before requesting buffers on either plane.
+ */
+#define V4L2_CID_MPEG_VIDEO_CUDA_GPU_ID (V4L2_CID_MPEG_BASE+558)
+
+/**
+ * Defines the Control ID to set drop frames interval for decoder.
+ *
+ * An integer value should be supplied with this control. A value of "x"
+ * indicates every "x"th frame should be given out from the decoder, rest shall
+ * dropped after decoding.
+ *
+ * @attention This control must be set after setting formats on both the planes
+ * and before requesting buffers on either plane.
+ */
+#define V4L2_CID_MPEG_VIDEODEC_DROP_FRAME_INTERVAL (V4L2_CID_MPEG_BASE+559)
+
+/**
+ * Control ID to enable/disable setting for attaching VP8/9 headers.
+ * Only to be used for VP8/9 pixel format not for H264/5.
+ *
+ * A boolean value should be supplied with this control.
+ * If value is false headers will be disabled and true will enable the headers.
+ *
+ * @attention This control should be set after setting formats on both the planes
+ * and before requesting buffers on either plane.
+ */
+ #define V4L2_CID_MPEG_VIDEOENC_VPX_HEADERS_WITH_FRAME (V4L2_CID_MPEG_BASE+560)
+
 /** @} */
 
 /** @addtogroup V4L2Dec */
@@ -1087,6 +1153,17 @@ enum v4l2_skip_frames_type {
     V4L2_SKIP_FRAMES_TYPE_NONREF = 1,
     /** Skip all frames except IDR */
     V4L2_SKIP_FRAMES_TYPE_DECODE_IDR_ONLY = 2,
+};
+
+/**
+ * Enum v4l2_cuda_mem_type, possible methods for cuda memory tpye. */
+enum v4l2_cuda_mem_type {
+    /** Memory type device. */
+    V4L2_CUDA_MEM_TYPE_DEVICE = 0,
+    /** Memory type host. */
+    V4L2_CUDA_MEM_TYPE_PINNED = 1,
+    /** Memory type unified. */
+    V4L2_CUDA_MEM_TYPE_UNIFIED = 2,
 };
 
 /**

--- a/nvmpi_dec.cpp
+++ b/nvmpi_dec.cpp
@@ -22,19 +22,19 @@ using namespace std;
 
 struct nvmpictx
 {
-	NvVideoDecoder *dec;
-	bool eos;
-	int index;
-	unsigned int coded_width;
-	unsigned int coded_height;
-	int dst_dma_fd;
-	int numberCaptureBuffers;	
+	NvVideoDecoder *dec{nullptr};
+	bool eos{false};
+	int index{0};
+	unsigned int coded_width{0};
+	unsigned int coded_height{0};
+	int dst_dma_fd{0};
+	int numberCaptureBuffers{0};
 	int dmaBufferFileDescriptor[MAX_BUFFERS];
 	nvPixFormat out_pixfmt;
-	unsigned int decoder_pixfmt;
-	std::thread * dec_capture_loop;
-	std::mutex* mutex;
-	std::queue<int> * frame_pools;
+	unsigned int decoder_pixfmt{0};
+	std::thread * dec_capture_loop{nullptr};
+	std::mutex* mutex{nullptr};
+	std::queue<int> * frame_pools{nullptr};
 	unsigned char * bufptr_0[MAX_BUFFERS];
 	unsigned char * bufptr_1[MAX_BUFFERS];
 	unsigned char * bufptr_2[MAX_BUFFERS];
@@ -44,6 +44,7 @@ struct nvmpictx
 };
 
 void respondToResolutionEvent(v4l2_format &format, v4l2_crop &crop,nvmpictx* ctx){
+	
 	int32_t minimumDecoderCaptureBuffers;
 	int ret=0;
 	NvBufferCreateParams input_params = {0};
@@ -185,7 +186,7 @@ void respondToResolutionEvent(v4l2_format &format, v4l2_crop &crop,nvmpictx* ctx
 
 void *dec_capture_loop_fcn(void *arg){
 	nvmpictx* ctx=(nvmpictx*)arg;
-
+	
 	struct v4l2_format v4l2Format;
 	struct v4l2_crop v4l2Crop;
 	struct v4l2_event v4l2Event;
@@ -207,6 +208,7 @@ void *dec_capture_loop_fcn(void *arg){
 
 	while (!(ctx->dec->isInError()||ctx->eos)){
 		NvBuffer *dec_buffer;
+		//printf("%lx dqEvent %d\n", (unsigned long)ctx, ctx->eos);
 		ret = ctx->dec->dqEvent(v4l2Event, false);	
 		if (ret == 0)
 		{
@@ -220,10 +222,11 @@ void *dec_capture_loop_fcn(void *arg){
 
 
 
-		while(true){
+		while(!ctx->eos){
 			struct v4l2_buffer v4l2_buf;
 			struct v4l2_plane planes[MAX_PLANES];
 			v4l2_buf.m.planes = planes;
+			//printf("%lx capture_plane.dqBuffer %d\n", (unsigned long)ctx, ctx->eos);
 			if (ctx->dec->capture_plane.dqBuffer(v4l2_buf, &dec_buffer, NULL, 0)){
 				if (errno == EAGAIN)
 				{
@@ -298,25 +301,31 @@ void *dec_capture_loop_fcn(void *arg){
 				buf_index=(buf_index+1)%MAX_BUFFERS;
 
 			}
+			
+			//printf("%lx check eos %d\n", (unsigned long)ctx, ctx->eos);
+			if (ctx->eos) {
+				return NULL;
+			}
+			
 			ctx->mutex->unlock();
 
 			v4l2_buf.m.planes[0].m.fd = ctx->dmaBufferFileDescriptor[v4l2_buf.index];
 			if (ctx->dec->capture_plane.qBuffer(v4l2_buf, NULL) < 0){
 				ERROR_MSG("Error while queueing buffer at decoder capture plane");
-
 			}
-
 		}
 
 	}
 }
 
 nvmpictx* nvmpi_create_decoder(nvCodingType codingType,nvPixFormat pixFormat){
-
+	
 	int ret;
 	log_level = LOG_LEVEL_INFO;
 
 	nvmpictx* ctx=new nvmpictx;
+	
+	//printf("%lx nvmpi_create_decoder\n", (unsigned long)ctx);
 
 	ctx->dec = NvVideoDecoder::createVideoDecoder("dec0");
 	TEST_ERROR(!ctx->dec, "Could not create decoder",ret);
@@ -384,7 +393,7 @@ nvmpictx* nvmpi_create_decoder(nvCodingType codingType,nvPixFormat pixFormat){
 
 int nvmpi_decoder_put_packet(nvmpictx* ctx,nvPacket* packet){
 	int ret;
-
+	
 	struct v4l2_buffer v4l2_buf;
 	struct v4l2_plane planes[MAX_PLANES];
 	NvBuffer *nvBuffer;
@@ -444,7 +453,7 @@ int nvmpi_decoder_put_packet(nvmpictx* ctx,nvPacket* packet){
 
 
 int nvmpi_decoder_get_frame(nvmpictx* ctx,nvFrame* frame){
-
+	
 	int ret,picture_index;
 
 	if(ctx->frame_pools->empty()){
@@ -475,13 +484,22 @@ int nvmpi_decoder_get_frame(nvmpictx* ctx,nvFrame* frame){
 
 int nvmpi_decoder_close(nvmpictx* ctx){
 
+	//printf("%lx nvmpi_decoder_close\n", (unsigned long)ctx);
+
 	ctx->mutex->lock();
-
 	ctx->eos=true;
-
 	ctx->mutex->unlock();
-
-	delete ctx->dec;
+	
+	ctx->dec->capture_plane.setStreamStatus(false);
+	
+	if (ctx->dec_capture_loop) {
+		//printf("%lx join capture loop\n", (unsigned long)ctx);
+		ctx->dec_capture_loop->join();
+		delete ctx->dec_capture_loop;
+		ctx->dec_capture_loop = nullptr;
+	}
+	
+	delete ctx->dec; ctx->dec = nullptr;
 
 	for(int index=0;index<MAX_BUFFERS;index++){
 		delete ctx->bufptr_0[index];
@@ -489,9 +507,11 @@ int nvmpi_decoder_close(nvmpictx* ctx){
 		delete ctx->bufptr_2[index];
 	}
 
-	delete ctx->frame_pools;
-	delete ctx;
+	delete ctx->mutex; ctx->mutex = nullptr;
+	delete ctx->frame_pools; ctx->frame_pools = nullptr;
+	delete ctx; ctx = nullptr;
 
+	printf("%lx end\n", (unsigned long)ctx);
 	return 0;
 }
 

--- a/nvmpi_dec.cpp
+++ b/nvmpi_dec.cpp
@@ -208,7 +208,7 @@ void *dec_capture_loop_fcn(void *arg){
 
 	while (!(ctx->dec->isInError()||ctx->eos)){
 		NvBuffer *dec_buffer;
-		//printf("%lx dqEvent %d\n", (unsigned long)ctx, ctx->eos);
+
 		ret = ctx->dec->dqEvent(v4l2Event, false);	
 		if (ret == 0)
 		{
@@ -226,7 +226,7 @@ void *dec_capture_loop_fcn(void *arg){
 			struct v4l2_buffer v4l2_buf;
 			struct v4l2_plane planes[MAX_PLANES];
 			v4l2_buf.m.planes = planes;
-			//printf("%lx capture_plane.dqBuffer %d\n", (unsigned long)ctx, ctx->eos);
+
 			if (ctx->dec->capture_plane.dqBuffer(v4l2_buf, &dec_buffer, NULL, 0)){
 				if (errno == EAGAIN)
 				{
@@ -302,7 +302,6 @@ void *dec_capture_loop_fcn(void *arg){
 
 			}
 			
-			//printf("%lx check eos %d\n", (unsigned long)ctx, ctx->eos);
 			if (ctx->eos) {
 				return NULL;
 			}
@@ -324,16 +323,12 @@ nvmpictx* nvmpi_create_decoder(nvCodingType codingType,nvPixFormat pixFormat){
 	log_level = LOG_LEVEL_INFO;
 
 	nvmpictx* ctx=new nvmpictx;
-	
-	//printf("%lx nvmpi_create_decoder\n", (unsigned long)ctx);
 
 	ctx->dec = NvVideoDecoder::createVideoDecoder("dec0");
 	TEST_ERROR(!ctx->dec, "Could not create decoder",ret);
 
-
 	ret=ctx->dec->subscribeEvent(V4L2_EVENT_RESOLUTION_CHANGE, 0, 0);
 	TEST_ERROR(ret < 0, "Could not subscribe to V4L2_EVENT_RESOLUTION_CHANGE", ret);
-
 
 	switch(codingType){
 		case NV_VIDEO_CodingH264:
@@ -484,8 +479,6 @@ int nvmpi_decoder_get_frame(nvmpictx* ctx,nvFrame* frame){
 
 int nvmpi_decoder_close(nvmpictx* ctx){
 
-	//printf("%lx nvmpi_decoder_close\n", (unsigned long)ctx);
-
 	ctx->mutex->lock();
 	ctx->eos=true;
 	ctx->mutex->unlock();
@@ -493,7 +486,6 @@ int nvmpi_decoder_close(nvmpictx* ctx){
 	ctx->dec->capture_plane.setStreamStatus(false);
 	
 	if (ctx->dec_capture_loop) {
-		//printf("%lx join capture loop\n", (unsigned long)ctx);
 		ctx->dec_capture_loop->join();
 		delete ctx->dec_capture_loop;
 		ctx->dec_capture_loop = nullptr;
@@ -511,7 +503,6 @@ int nvmpi_decoder_close(nvmpictx* ctx){
 	delete ctx->frame_pools; ctx->frame_pools = nullptr;
 	delete ctx; ctx = nullptr;
 
-	printf("%lx end\n", (unsigned long)ctx);
 	return 0;
 }
 


### PR DESCRIPTION
My project uses ffmpeg libraries to open lots of files and closing then and I noticed a build-up of threads caused by the hanging capture loop. I fixed that and I also fixed not deallocating a bunch of resources correctly. There are however more memory leaks in the Nvidia API part, which I will get to later.