### PR TITLE
Reduce decoding latency when AV_CODEC_FLAG_LOW_DELAY is set

### DIFF
--- a/ffmpeg_nvmpi.patch
+++ b/ffmpeg_nvmpi.patch
@@ -184,7 +184,7 @@ index d2f9a39..04dc62b 100644
  
 diff --git a/libavcodec/nvmpi_dec.c b/libavcodec/nvmpi_dec.c
 new file mode 100644
-index 0000000..1d92aeb
+index 0000000..694195c
 --- /dev/null
 +++ b/libavcodec/nvmpi_dec.c
 @@ -0,0 +1,166 @@
@@ -281,7 +281,7 @@ index 0000000..1d92aeb
 +		res=nvmpi_decoder_put_packet(nvmpi_context->ctx,&packet);
 +	}
 +
-+	res=nvmpi_decoder_get_frame(nvmpi_context->ctx,&_nvframe);
++	res=nvmpi_decoder_get_frame(nvmpi_context->ctx,&_nvframe,avctx->flags & AV_CODEC_FLAG_LOW_DELAY);
 +
 +	if(res<0)
 +		return avpkt->size;

--- a/nvmpi.h
+++ b/nvmpi.h
@@ -1,6 +1,7 @@
 #ifndef __NVMPI_H__
 #define __NVMPI_H__
 #include <stdlib.h>
+#include <stdbool.h>
 
 typedef struct nvmpictx nvmpictx;
 
@@ -70,7 +71,7 @@ extern "C" {
 
 	int nvmpi_decoder_put_packet(nvmpictx* ctx,nvPacket* packet);
 
-	int nvmpi_decoder_get_frame(nvmpictx* ctx,nvFrame* frame);
+	int nvmpi_decoder_get_frame(nvmpictx* ctx,nvFrame* frame,bool wait);
 
 	int nvmpi_decoder_close(nvmpictx* ctx);
 


### PR DESCRIPTION
For normal decoding, it's ideal to asynchronously submit frames to get the most throughput out of the decoder. For low latency applications, this is not ideal because it ensures that a decoded frame will be delayed at least until the next frame is submitted (usually 2 or 3 frames delayed, depending on the resolution and bitrate).

To avoid this extra latency, wait for a frame to be ready (or EOS/error) if AV_CODEC_FLAG_LOW_DELAY is specified. This change reduces 2560x1440 60 FPS frame decode latency from 50 ms to under 16 ms.