### PR TITLE
Add minor hack/fix for when apps dont set pix_fmt before doing decode…

### DIFF
--- a/ffmpeg_nvmpi.patch
+++ b/ffmpeg_nvmpi.patch
@@ -1,8 +1,7 @@
-diff --git a/configure b/configure
-index 34c2adb..a861a73 100755
---- a/configure
-+++ b/configure
-@@ -340,6 +340,7 @@ External library support:
+diff -Naur ffmpeg/configure ffmpeg2/configure
+--- ffmpeg/configure	2021-01-23 23:16:56.260744613 -0800
++++ ffmpeg2/configure	2021-01-25 13:57:08.715764573 -0800
+@@ -340,6 +340,7 @@
    --disable-vaapi          disable Video Acceleration API (mainly Unix/Intel) code [autodetect]
    --disable-vdpau          disable Nvidia Video Decode and Presentation API for Unix code [autodetect]
    --disable-videotoolbox   disable VideoToolbox code [autodetect]
@@ -10,7 +9,7 @@ index 34c2adb..a861a73 100755
  
  Toolchain options:
    --arch=ARCH              select architecture [$arch]
-@@ -1851,6 +1852,7 @@ HWACCEL_LIBRARY_LIST="
+@@ -1851,6 +1852,7 @@
      mmal
      omx
      opencl
@@ -18,7 +17,7 @@ index 34c2adb..a861a73 100755
  "
  
  DOCUMENT_LIST="
-@@ -3014,11 +3016,14 @@ h264_mediacodec_decoder_deps="mediacodec"
+@@ -3014,11 +3016,14 @@
  h264_mediacodec_decoder_select="h264_mp4toannexb_bsf h264_parser"
  h264_mmal_decoder_deps="mmal"
  h264_nvenc_encoder_deps="nvenc"
@@ -33,7 +32,7 @@ index 34c2adb..a861a73 100755
  h264_vaapi_encoder_select="cbs_h264 vaapi_encode"
  h264_v4l2m2m_decoder_deps="v4l2_m2m h264_v4l2_m2m"
  h264_v4l2m2m_decoder_select="h264_mp4toannexb_bsf"
-@@ -3029,10 +3034,13 @@ hevc_cuvid_decoder_select="hevc_mp4toannexb_bsf"
+@@ -3029,10 +3034,13 @@
  hevc_mediacodec_decoder_deps="mediacodec"
  hevc_mediacodec_decoder_select="hevc_mp4toannexb_bsf hevc_parser"
  hevc_nvenc_encoder_deps="nvenc"
@@ -47,7 +46,7 @@ index 34c2adb..a861a73 100755
  hevc_vaapi_encoder_deps="VAEncPictureParameterBufferHEVC"
  hevc_vaapi_encoder_select="cbs_h265 vaapi_encode"
  hevc_v4l2m2m_decoder_deps="v4l2_m2m hevc_v4l2_m2m"
-@@ -3047,6 +3055,7 @@ mpeg1_cuvid_decoder_deps="cuvid"
+@@ -3047,6 +3055,7 @@
  mpeg1_v4l2m2m_decoder_deps="v4l2_m2m mpeg1_v4l2_m2m"
  mpeg2_crystalhd_decoder_select="crystalhd"
  mpeg2_cuvid_decoder_deps="cuvid"
@@ -55,7 +54,7 @@ index 34c2adb..a861a73 100755
  mpeg2_mmal_decoder_deps="mmal"
  mpeg2_mediacodec_decoder_deps="mediacodec"
  mpeg2_qsv_decoder_select="qsvdec mpegvideo_parser"
-@@ -3055,6 +3064,7 @@ mpeg2_vaapi_encoder_select="cbs_mpeg2 vaapi_encode"
+@@ -3055,6 +3064,7 @@
  mpeg2_v4l2m2m_decoder_deps="v4l2_m2m mpeg2_v4l2_m2m"
  mpeg4_crystalhd_decoder_select="crystalhd"
  mpeg4_cuvid_decoder_deps="cuvid"
@@ -63,7 +62,7 @@ index 34c2adb..a861a73 100755
  mpeg4_mediacodec_decoder_deps="mediacodec"
  mpeg4_mmal_decoder_deps="mmal"
  mpeg4_omx_encoder_deps="omx"
-@@ -3069,6 +3079,7 @@ vc1_mmal_decoder_deps="mmal"
+@@ -3069,6 +3079,7 @@
  vc1_qsv_decoder_select="qsvdec vc1_parser"
  vc1_v4l2m2m_decoder_deps="v4l2_m2m vc1_v4l2_m2m"
  vp8_cuvid_decoder_deps="cuvid"
@@ -71,7 +70,7 @@ index 34c2adb..a861a73 100755
  vp8_mediacodec_decoder_deps="mediacodec"
  vp8_qsv_decoder_select="qsvdec vp8_parser"
  vp8_rkmpp_decoder_deps="rkmpp"
-@@ -3077,6 +3088,7 @@ vp8_vaapi_encoder_select="vaapi_encode"
+@@ -3077,6 +3088,7 @@
  vp8_v4l2m2m_decoder_deps="v4l2_m2m vp8_v4l2_m2m"
  vp8_v4l2m2m_encoder_deps="v4l2_m2m vp8_v4l2_m2m"
  vp9_cuvid_decoder_deps="cuvid"
@@ -79,7 +78,7 @@ index 34c2adb..a861a73 100755
  vp9_mediacodec_decoder_deps="mediacodec"
  vp9_rkmpp_decoder_deps="rkmpp"
  vp9_vaapi_encoder_deps="VAEncPictureParameterBufferVP9"
-@@ -6366,6 +6378,7 @@ enabled rkmpp             && { require_pkg_config rkmpp rockchip_mpp  rockchip/r
+@@ -6366,6 +6378,7 @@
                                   die "ERROR: rkmpp requires --enable-libdrm"; }
                               }
  enabled vapoursynth       && require_pkg_config vapoursynth "vapoursynth-script >= 42" VSScript.h vsscript_init
@@ -87,11 +86,10 @@ index 34c2adb..a861a73 100755
  
  
  if enabled gcrypt; then
-diff --git a/libavcodec/Makefile b/libavcodec/Makefile
-index 3cd73fb..c3ed5cc 100644
---- a/libavcodec/Makefile
-+++ b/libavcodec/Makefile
-@@ -354,6 +354,8 @@ OBJS-$(CONFIG_H264_MMAL_DECODER)       += mmaldec.o
+diff -Naur ffmpeg/libavcodec/Makefile ffmpeg2/libavcodec/Makefile
+--- ffmpeg/libavcodec/Makefile	2021-01-23 23:16:56.320745424 -0800
++++ ffmpeg2/libavcodec/Makefile	2021-01-25 13:57:08.715764573 -0800
+@@ -354,6 +354,8 @@
  OBJS-$(CONFIG_H264_NVENC_ENCODER)      += nvenc_h264.o
  OBJS-$(CONFIG_NVENC_ENCODER)           += nvenc_h264.o
  OBJS-$(CONFIG_NVENC_H264_ENCODER)      += nvenc_h264.o
@@ -100,7 +98,7 @@ index 3cd73fb..c3ed5cc 100644
  OBJS-$(CONFIG_H264_OMX_ENCODER)        += omx.o
  OBJS-$(CONFIG_H264_QSV_DECODER)        += qsvdec_h2645.o
  OBJS-$(CONFIG_H264_QSV_ENCODER)        += qsvenc_h264.o
-@@ -379,6 +381,8 @@ OBJS-$(CONFIG_HEVC_QSV_ENCODER)        += qsvenc_hevc.o hevc_ps_enc.o       \
+@@ -379,6 +381,8 @@
  OBJS-$(CONFIG_HEVC_RKMPP_DECODER)      += rkmppdec.o
  OBJS-$(CONFIG_HEVC_VAAPI_ENCODER)      += vaapi_encode_h265.o h265_profile_level.o
  OBJS-$(CONFIG_HEVC_V4L2M2M_DECODER)    += v4l2_m2m_dec.o
@@ -109,7 +107,7 @@ index 3cd73fb..c3ed5cc 100644
  OBJS-$(CONFIG_HEVC_V4L2M2M_ENCODER)    += v4l2_m2m_enc.o
  OBJS-$(CONFIG_HNM4_VIDEO_DECODER)      += hnm4video.o
  OBJS-$(CONFIG_HQ_HQA_DECODER)          += hq_hqa.o hq_hqadata.o hq_hqadsp.o \
-@@ -464,11 +468,13 @@ OBJS-$(CONFIG_MPEG2_QSV_ENCODER)       += qsvenc_mpeg2.o
+@@ -464,11 +468,13 @@
  OBJS-$(CONFIG_MPEG2VIDEO_DECODER)      += mpeg12dec.o mpeg12.o mpeg12data.o
  OBJS-$(CONFIG_MPEG2VIDEO_ENCODER)      += mpeg12enc.o mpeg12.o
  OBJS-$(CONFIG_MPEG2_CUVID_DECODER)     += cuviddec.o
@@ -123,7 +121,7 @@ index 3cd73fb..c3ed5cc 100644
  OBJS-$(CONFIG_MPEG4_MEDIACODEC_DECODER) += mediacodecdec.o
  OBJS-$(CONFIG_MPEG4_OMX_ENCODER)       += omx.o
  OBJS-$(CONFIG_MPEG4_V4L2M2M_DECODER)   += v4l2_m2m_dec.o
-@@ -669,6 +675,7 @@ OBJS-$(CONFIG_VP6_DECODER)             += vp6.o vp56.o vp56data.o \
+@@ -669,6 +675,7 @@
  OBJS-$(CONFIG_VP7_DECODER)             += vp8.o vp56rac.o
  OBJS-$(CONFIG_VP8_DECODER)             += vp8.o vp56rac.o
  OBJS-$(CONFIG_VP8_CUVID_DECODER)       += cuviddec.o
@@ -131,7 +129,7 @@ index 3cd73fb..c3ed5cc 100644
  OBJS-$(CONFIG_VP8_MEDIACODEC_DECODER)  += mediacodecdec.o
  OBJS-$(CONFIG_VP8_QSV_DECODER)         += qsvdec_other.o
  OBJS-$(CONFIG_VP8_RKMPP_DECODER)       += rkmppdec.o
-@@ -679,6 +686,7 @@ OBJS-$(CONFIG_VP9_DECODER)             += vp9.o vp9data.o vp9dsp.o vp9lpf.o vp9r
+@@ -679,6 +686,7 @@
                                            vp9block.o vp9prob.o vp9mvs.o vp56rac.o \
                                            vp9dsp_8bpp.o vp9dsp_10bpp.o vp9dsp_12bpp.o
  OBJS-$(CONFIG_VP9_CUVID_DECODER)       += cuviddec.o
@@ -139,11 +137,10 @@ index 3cd73fb..c3ed5cc 100644
  OBJS-$(CONFIG_VP9_MEDIACODEC_DECODER)  += mediacodecdec.o
  OBJS-$(CONFIG_VP9_RKMPP_DECODER)       += rkmppdec.o
  OBJS-$(CONFIG_VP9_VAAPI_ENCODER)       += vaapi_encode_vp9.o
-diff --git a/libavcodec/allcodecs.c b/libavcodec/allcodecs.c
-index d2f9a39..04dc62b 100644
---- a/libavcodec/allcodecs.c
-+++ b/libavcodec/allcodecs.c
-@@ -143,11 +143,15 @@ extern AVCodec ff_h264_mediacodec_decoder;
+diff -Naur ffmpeg/libavcodec/allcodecs.c ffmpeg2/libavcodec/allcodecs.c
+--- ffmpeg/libavcodec/allcodecs.c	2021-01-23 23:16:56.352745857 -0800
++++ ffmpeg2/libavcodec/allcodecs.c	2021-01-25 13:57:08.719764465 -0800
+@@ -143,11 +143,15 @@
  extern AVCodec ff_h264_mmal_decoder;
  extern AVCodec ff_h264_qsv_decoder;
  extern AVCodec ff_h264_rkmpp_decoder;
@@ -159,7 +156,7 @@ index d2f9a39..04dc62b 100644
  extern AVCodec ff_hevc_v4l2m2m_decoder;
  extern AVCodec ff_hnm4_video_decoder;
  extern AVCodec ff_hq_hqa_decoder;
-@@ -766,18 +770,22 @@ extern AVCodec ff_mjpeg_qsv_encoder;
+@@ -766,18 +770,22 @@
  extern AVCodec ff_mjpeg_vaapi_encoder;
  extern AVCodec ff_mpeg1_cuvid_decoder;
  extern AVCodec ff_mpeg2_cuvid_decoder;
@@ -182,12 +179,10 @@ index d2f9a39..04dc62b 100644
  extern AVCodec ff_vp9_mediacodec_decoder;
  extern AVCodec ff_vp9_vaapi_encoder;
  
-diff --git a/libavcodec/nvmpi_dec.c b/libavcodec/nvmpi_dec.c
-new file mode 100644
-index 0000000..694195c
---- /dev/null
-+++ b/libavcodec/nvmpi_dec.c
-@@ -0,0 +1,166 @@
+diff -Naur ffmpeg/libavcodec/nvmpi_dec.c ffmpeg2/libavcodec/nvmpi_dec.c
+--- ffmpeg/libavcodec/nvmpi_dec.c	1969-12-31 16:00:00.000000000 -0800
++++ ffmpeg2/libavcodec/nvmpi_dec.c	2021-01-25 15:28:29.327551173 -0800
+@@ -0,0 +1,176 @@
 +#include <stdio.h>
 +#include <stdlib.h>
 +#include <sys/time.h>
@@ -229,27 +224,32 @@ index 0000000..694195c
 +
 +static int nvmpi_init_decoder(AVCodecContext *avctx){
 +
-+	int ret=0;
-+
 +	nvmpiDecodeContext *nvmpi_context = avctx->priv_data;
 +	nvCodingType codectype=NV_VIDEO_CodingUnused;
 +
 +	codectype =nvmpi_get_codingtype(avctx);
 +	if (codectype == NV_VIDEO_CodingUnused) {
 +		av_log(avctx, AV_LOG_ERROR, "Unknown codec type (%d).\n", avctx->codec_id);
-+		ret = AVERROR_UNKNOWN;
-+		return ret;
++		return AVERROR_UNKNOWN;
++	}
++
++	//Workaround for default pix_fmt not being set, so check if it isnt set and set it,
++   //or if it is set, but isnt set to something we can work with.
++
++	if(avctx->pix_fmt ==AV_PIX_FMT_NONE){
++		 avctx->pix_fmt=AV_PIX_FMT_YUV420P;
++	}else if(avctx-> pix_fmt != AV_PIX_FMT_YUV420P){
++		av_log(avctx, AV_LOG_ERROR, "Invalid Pix_FMT for NVMPI Only yuv420p is supported\n");
++		return AVERROR_INVALIDDATA;
 +	}
 +
 +	nvmpi_context->ctx=nvmpi_create_decoder(codectype,NV_PIX_YUV420);
 +
 +	if(!nvmpi_context->ctx){
-+		av_log(avctx, AV_LOG_ERROR, "Failed to nvmpi_create_decoder (code = %d).\n", ret);
-+		ret = AVERROR_UNKNOWN;
-+		return ret;
++		av_log(avctx, AV_LOG_ERROR, "Failed to nvmpi_create_decoder (code = %d).\n", AVERROR_EXTERNAL);
++		return AVERROR_EXTERNAL;
 +	}
-+
-+	return ret;
++   return 0;
 +
 +}
 +
@@ -285,7 +285,6 @@ index 0000000..694195c
 +
 +	if(res<0)
 +		return avpkt->size;
-+
 +
 +	if (ff_get_buffer(avctx, frame, 0) < 0) {
 +		return AVERROR(ENOMEM);
@@ -354,11 +353,9 @@ index 0000000..694195c
 +NVMPI_DEC(mpeg4, AV_CODEC_ID_MPEG4,NULL);
 +NVMPI_DEC(vp9,  AV_CODEC_ID_VP9,NULL);
 +NVMPI_DEC(vp8,  AV_CODEC_ID_VP8,NULL);
-diff --git a/libavcodec/nvmpi_enc.c b/libavcodec/nvmpi_enc.c
-new file mode 100644
-index 0000000..0e1390e
---- /dev/null
-+++ b/libavcodec/nvmpi_enc.c
+diff -Naur ffmpeg/libavcodec/nvmpi_enc.c ffmpeg2/libavcodec/nvmpi_enc.c
+--- ffmpeg/libavcodec/nvmpi_enc.c	1969-12-31 16:00:00.000000000 -0800
++++ ffmpeg2/libavcodec/nvmpi_enc.c	2021-01-25 13:57:08.719764465 -0800
 @@ -0,0 +1,272 @@
 +#include <nvmpi.h>
 +#include "avcodec.h"

--- a/ffmpeg_nvmpi.patch
+++ b/ffmpeg_nvmpi.patch
@@ -182,7 +182,7 @@ diff -Naur ffmpeg/libavcodec/allcodecs.c ffmpeg2/libavcodec/allcodecs.c
 diff -Naur ffmpeg/libavcodec/nvmpi_dec.c ffmpeg2/libavcodec/nvmpi_dec.c
 --- ffmpeg/libavcodec/nvmpi_dec.c	1969-12-31 16:00:00.000000000 -0800
 +++ ffmpeg2/libavcodec/nvmpi_dec.c	2021-01-25 15:28:29.327551173 -0800
-@@ -0,0 +1,176 @@
+@@ -0,0 +1,169 @@
 +#include <stdio.h>
 +#include <stdlib.h>
 +#include <sys/time.h>


### PR DESCRIPTION
…r init. This fixes use of nvmpi codecs with apps like mpv, kodi, and vlc. All of those still need to be force redirected to the nvmpi codec, and there isnt a pretty way to do that.