### PR TITLE
IP cameras send YUVJ420P streams, which is almost the same as YUV420P

### DIFF
--- a/ffmpeg_nvmpi.patch
+++ b/ffmpeg_nvmpi.patch
@@ -239,12 +239,12 @@ index 0000000..f82aa61
 +	}
 +
 +	//Workaround for default pix_fmt not being set, so check if it isnt set and set it,
-+   //or if it is set, but isnt set to something we can work with.
++	//or if it is set, but isnt set to something we can work with.
 +
 +	if(avctx->pix_fmt ==AV_PIX_FMT_NONE){
 +		 avctx->pix_fmt=AV_PIX_FMT_YUV420P;
-+	}else if(avctx-> pix_fmt != AV_PIX_FMT_YUV420P){
-+		av_log(avctx, AV_LOG_ERROR, "Invalid Pix_FMT for NVMPI Only yuv420p is supported\n");
++	}else if((avctx->pix_fmt != AV_PIX_FMT_YUV420P) && (avctx->pix_fmt != AV_PIX_FMT_YUVJ420P)){
++		av_log(avctx, AV_LOG_ERROR, "Invalid Pix_FMT for NVMPI: Only YUV420P and YUVJ420P are supported\n");
 +		return AVERROR_INVALIDDATA;
 +	}
 +


### PR DESCRIPTION
The check introduced on January 26 is too strict; YUVJ420P can also be accepted as a pixel format. This was working properly before that change.