### PR TITLE
Add libv4l2 to the pkg-config in order not to fail linking ffmpeg to nvmpi.so on the environments that doesn't support linking shared libs "like a chain"

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -3,28 +3,28 @@ project(nvmpi VERSION 1.0.0 DESCRIPTION "nvidia multimedia api")
 
 set(CMAKE_C_FLAGS“$ {CMAKE_C_FLAGS} -fPIC”)
 set(CMAKE_CXX_FLAGS“$ {CMAKE_CXX_FLAGS} -fPIC”)
-#set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-rpath-link=/lib")
-#set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-rpath-link=/usr/lib/aarch64-linux-gnu")
 set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-rpath-link=/usr/lib/aarch64-linux-gnu/tegra")
 set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-rpath-link=/usr/local/cuda/lib64")
 
-find_library(LIB_NVBUF nvbuf_utils PATHS /usr/lib/aarch64-linux-gnu/tegra)
-find_library(LIB_V4L2 nvv4l2 PATHS /usr/lib/aarch64-linux-gnu/tegra)
+find_library(LIB_NVBUF nvbuf_utils PATHS ${BITBAKE_SYSROOT}/usr/lib/aarch64-linux-gnu/tegra)
+find_package(PkgConfig)
+pkg_check_modules(LIB_V4L2 REQUIRED libv4l2)
 find_package (Threads)
-#find_library(LIB_DRM drm PATHS /usr/lib/aarch64-linux-gnu/tegra)
-#find_library(LIB_EGL EGL PATHS /usr/lib/aarch64-linux-gnu/tegra)
+#find_library(LIB_DRM drm PATHS ${BITBAKE_SYSROOT}/usr/lib/aarch64-linux-gnu/tegra)
+#find_library(LIB_EGL EGL PATHS ${BITBAKE_SYSROOT}/usr/lib/aarch64-linux-gnu/tegra)
 
+include(GNUInstallDirs)
 add_library(nvmpi SHARED
     nvmpi_dec.cpp
     nvmpi_enc.cpp
-    /usr/src/jetson_multimedia_api/samples/common/classes/NvBuffer.cpp
-    /usr/src/jetson_multimedia_api/samples/common/classes/NvElement.cpp
-    /usr/src/jetson_multimedia_api/samples/common/classes/NvElementProfiler.cpp
-    /usr/src/jetson_multimedia_api/samples/common/classes/NvLogging.cpp
-    /usr/src/jetson_multimedia_api/samples/common/classes/NvV4l2Element.cpp
-    /usr/src/jetson_multimedia_api/samples/common/classes/NvV4l2ElementPlane.cpp
-    /usr/src/jetson_multimedia_api/samples/common/classes/NvVideoDecoder.cpp
-    /usr/src/jetson_multimedia_api/samples/common/classes/NvVideoEncoder.cpp
+    ${BITBAKE_SYSROOT}/usr/src/jetson_multimedia_api/samples/common/classes/NvBuffer.cpp
+    ${BITBAKE_SYSROOT}/usr/src/jetson_multimedia_api/samples/common/classes/NvElement.cpp
+    ${BITBAKE_SYSROOT}/usr/src/jetson_multimedia_api/samples/common/classes/NvElementProfiler.cpp
+    ${BITBAKE_SYSROOT}/usr/src/jetson_multimedia_api/samples/common/classes/NvLogging.cpp
+    ${BITBAKE_SYSROOT}/usr/src/jetson_multimedia_api/samples/common/classes/NvV4l2Element.cpp
+    ${BITBAKE_SYSROOT}/usr/src/jetson_multimedia_api/samples/common/classes/NvV4l2ElementPlane.cpp
+    ${BITBAKE_SYSROOT}/usr/src/jetson_multimedia_api/samples/common/classes/NvVideoDecoder.cpp
+    ${BITBAKE_SYSROOT}/usr/src/jetson_multimedia_api/samples/common/classes/NvVideoEncoder.cpp
     #common/NvVideoConverter.cpp
     #common/NvApplicationProfiler.cpp
     #common/NvEglRenderer.cpp
@@ -34,12 +34,11 @@ add_library(nvmpi SHARED
 set_target_properties(nvmpi PROPERTIES VERSION ${PROJECT_VERSION})
 set_target_properties(nvmpi PROPERTIES PUBLIC_HEADER nvmpi.h)
 target_link_libraries(nvmpi PRIVATE ${CMAKE_THREAD_LIBS_INIT} ${LIB_NVBUF}  ${LIB_V4L2})
-target_include_directories(nvmpi PRIVATE /usr/src/jetson_multimedia_api/include)
-target_include_directories(nvmpi PRIVATE /usr/local/cuda/include)
+target_include_directories(nvmpi PRIVATE ${BITBAKE_SYSROOT}/usr/src/jetson_multimedia_api/include)
+target_include_directories(nvmpi PRIVATE ${BITBAKE_SYSROOT}/usr/local/cuda/include)
 configure_file(nvmpi.pc.in nvmpi.pc @ONLY)
-include(GNUInstallDirs)
 install(TARGETS ${PROJECT_NAME}
 	    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
 	        PUBLIC_HEADER DESTINATION ${CMAKE_INSTALL_INCLUDEDIR})
 install(FILES ${CMAKE_BINARY_DIR}/nvmpi.pc
-	    DESTINATION ${CMAKE_INSTALL_DATAROOTDIR}/pkgconfig)
+	    DESTINATION ${CMAKE_INSTALL_LIBDIR}/pkgconfig)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -9,7 +9,8 @@ set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-rpath-link=/usr
 set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} -Wl,-rpath-link=/usr/local/cuda/lib64")
 
 find_library(LIB_NVBUF nvbuf_utils PATHS /usr/lib/aarch64-linux-gnu/tegra)
-find_library(LIB_V4L2 nvv4l2 PATHS /usr/lib/aarch64-linux-gnu/tegra)
+find_package(PkgConfig)
+pkg_check_modules(LIB_V4L2 REQUIRED libv4l2)
 find_package (Threads)
 #find_library(LIB_DRM drm PATHS /usr/lib/aarch64-linux-gnu/tegra)
 #find_library(LIB_EGL EGL PATHS /usr/lib/aarch64-linux-gnu/tegra)

--- a/nvmpi.pc.in
+++ b/nvmpi.pc.in
@@ -7,6 +7,6 @@ Name: @PROJECT_NAME@
 Description: @PROJECT_DESCRIPTION@
 Version: @PROJECT_VERSION@
 
-Requires:
+Requires: libv4l2
 Libs: -L${libdir} -lnvmpi
 Cflags: -I${includedir} 


### PR DESCRIPTION
On Ubuntu the linker refers to rpath location by default. But when other environments like openembedded+bitbake or something like this, it is not. Adding libv4l2 to the Requires in pkg-config is essential since the program is slightly dependent on v4l2 function and lacking it can cause an issue on linking.
