### PR TITLE
Port to ffmpeg 4.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ L4T Multimedia API for ffmpeg
 	
 **2.patch ffmpeg and build**
 
-    git clone git://source.ffmpeg.org/ffmpeg.git -b release/4.2 --depth=1
+    git clone git://source.ffmpeg.org/ffmpeg.git -b release/4.4 --depth=1
     cd ffmpeg
     wget https://github.com/jocover/jetson-ffmpeg/raw/master/ffmpeg_nvmpi.patch
     git apply ffmpeg_nvmpi.patch

--- a/ffmpeg_nvmpi.patch
+++ b/ffmpeg_nvmpi.patch
@@ -1,8 +1,8 @@
 diff --git a/configure b/configure
-index 6a7a85c..5810ab5 100755
+index 98113c9..19ad8ca 100755
 --- a/configure
 +++ b/configure
-@@ -340,6 +340,7 @@ External library support:
+@@ -349,6 +349,7 @@ External library support:
    --disable-vaapi          disable Video Acceleration API (mainly Unix/Intel) code [autodetect]
    --disable-vdpau          disable Nvidia Video Decode and Presentation API for Unix code [autodetect]
    --disable-videotoolbox   disable VideoToolbox code [autodetect]
@@ -10,22 +10,23 @@ index 6a7a85c..5810ab5 100755
  
  Toolchain options:
    --arch=ARCH              select architecture [$arch]
-@@ -1851,6 +1852,7 @@ HWACCEL_LIBRARY_LIST="
-     mmal
+@@ -1869,6 +1870,7 @@ HWACCEL_LIBRARY_LIST="
      omx
      opencl
+     vulkan
 +    nvmpi
  "
  
  DOCUMENT_LIST="
-@@ -3014,11 +3016,14 @@ h264_mediacodec_decoder_deps="mediacodec"
- h264_mediacodec_decoder_select="h264_mp4toannexb_bsf h264_parser"
+@@ -3081,12 +3083,15 @@ h264_mediacodec_decoder_select="h264_mp4toannexb_bsf h264_parser"
+ h264_mf_encoder_deps="mediafoundation"
  h264_mmal_decoder_deps="mmal"
  h264_nvenc_encoder_deps="nvenc"
 +h264_nvmpi_encoder_deps="nvmpi"
+ h264_nvenc_encoder_select="atsc_a53"
  h264_omx_encoder_deps="omx"
- h264_qsv_decoder_select="h264_mp4toannexb_bsf h264_parser qsvdec"
- h264_qsv_encoder_select="qsvenc"
+ h264_qsv_decoder_select="h264_mp4toannexb_bsf qsvdec"
+ h264_qsv_encoder_select="atsc_a53 qsvenc"
  h264_rkmpp_decoder_deps="rkmpp"
  h264_rkmpp_decoder_select="h264_mp4toannexb_bsf"
 +h264_nvmpi_decoder_deps="nvmpi"
@@ -33,12 +34,12 @@ index 6a7a85c..5810ab5 100755
  h264_vaapi_encoder_select="cbs_h264 vaapi_encode"
  h264_v4l2m2m_decoder_deps="v4l2_m2m h264_v4l2_m2m"
  h264_v4l2m2m_decoder_select="h264_mp4toannexb_bsf"
-@@ -3029,10 +3034,13 @@ hevc_cuvid_decoder_select="hevc_mp4toannexb_bsf"
- hevc_mediacodec_decoder_deps="mediacodec"
- hevc_mediacodec_decoder_select="hevc_mp4toannexb_bsf hevc_parser"
+@@ -3099,10 +3104,13 @@ hevc_mediacodec_decoder_select="hevc_mp4toannexb_bsf hevc_parser"
+ hevc_mf_encoder_deps="mediafoundation"
  hevc_nvenc_encoder_deps="nvenc"
+ hevc_nvenc_encoder_select="atsc_a53"
 +hevc_nvmpi_encoder_deps="nvmpi"
- hevc_qsv_decoder_select="hevc_mp4toannexb_bsf hevc_parser qsvdec"
+ hevc_qsv_decoder_select="hevc_mp4toannexb_bsf qsvdec"
  hevc_qsv_encoder_select="hevcparse qsvenc"
  hevc_rkmpp_decoder_deps="rkmpp"
  hevc_rkmpp_decoder_select="hevc_mp4toannexb_bsf"
@@ -47,15 +48,15 @@ index 6a7a85c..5810ab5 100755
  hevc_vaapi_encoder_deps="VAEncPictureParameterBufferHEVC"
  hevc_vaapi_encoder_select="cbs_h265 vaapi_encode"
  hevc_v4l2m2m_decoder_deps="v4l2_m2m hevc_v4l2_m2m"
-@@ -3047,6 +3055,7 @@ mpeg1_cuvid_decoder_deps="cuvid"
+@@ -3119,6 +3127,7 @@ mpeg1_cuvid_decoder_deps="cuvid"
  mpeg1_v4l2m2m_decoder_deps="v4l2_m2m mpeg1_v4l2_m2m"
  mpeg2_crystalhd_decoder_select="crystalhd"
  mpeg2_cuvid_decoder_deps="cuvid"
 +mpeg2_nvmpi_decoder_deps="nvmpi"
  mpeg2_mmal_decoder_deps="mmal"
  mpeg2_mediacodec_decoder_deps="mediacodec"
- mpeg2_qsv_decoder_select="qsvdec mpegvideo_parser"
-@@ -3055,6 +3064,7 @@ mpeg2_vaapi_encoder_select="cbs_mpeg2 vaapi_encode"
+ mpeg2_qsv_decoder_select="qsvdec"
+@@ -3127,6 +3136,7 @@ mpeg2_vaapi_encoder_select="cbs_mpeg2 vaapi_encode"
  mpeg2_v4l2m2m_decoder_deps="v4l2_m2m mpeg2_v4l2_m2m"
  mpeg4_crystalhd_decoder_select="crystalhd"
  mpeg4_cuvid_decoder_deps="cuvid"
@@ -63,53 +64,53 @@ index 6a7a85c..5810ab5 100755
  mpeg4_mediacodec_decoder_deps="mediacodec"
  mpeg4_mmal_decoder_deps="mmal"
  mpeg4_omx_encoder_deps="omx"
-@@ -3069,6 +3079,7 @@ vc1_mmal_decoder_deps="mmal"
- vc1_qsv_decoder_select="qsvdec vc1_parser"
+@@ -3141,6 +3151,7 @@ vc1_mmal_decoder_deps="mmal"
+ vc1_qsv_decoder_select="qsvdec"
  vc1_v4l2m2m_decoder_deps="v4l2_m2m vc1_v4l2_m2m"
  vp8_cuvid_decoder_deps="cuvid"
 +vp8_nvmpi_decoder_deps="nvmpi"
  vp8_mediacodec_decoder_deps="mediacodec"
- vp8_qsv_decoder_select="qsvdec vp8_parser"
+ vp8_qsv_decoder_select="qsvdec"
  vp8_rkmpp_decoder_deps="rkmpp"
-@@ -3077,6 +3088,7 @@ vp8_vaapi_encoder_select="vaapi_encode"
+@@ -3149,6 +3160,7 @@ vp8_vaapi_encoder_select="vaapi_encode"
  vp8_v4l2m2m_decoder_deps="v4l2_m2m vp8_v4l2_m2m"
  vp8_v4l2m2m_encoder_deps="v4l2_m2m vp8_v4l2_m2m"
  vp9_cuvid_decoder_deps="cuvid"
 +vp9_nvmpi_decoder_deps="nvmpi"
  vp9_mediacodec_decoder_deps="mediacodec"
+ vp9_qsv_decoder_select="qsvdec"
  vp9_rkmpp_decoder_deps="rkmpp"
- vp9_vaapi_encoder_deps="VAEncPictureParameterBufferVP9"
-@@ -6366,6 +6378,7 @@ enabled rkmpp             && { require_pkg_config rkmpp rockchip_mpp  rockchip/r
+@@ -6538,6 +6550,7 @@ enabled rkmpp             && { require_pkg_config rkmpp rockchip_mpp  rockchip/r
                                   die "ERROR: rkmpp requires --enable-libdrm"; }
                               }
  enabled vapoursynth       && require_pkg_config vapoursynth "vapoursynth-script >= 42" VSScript.h vsscript_init
-+enabled nvmpi		  && require_pkg_config nvmpi nvmpi nvmpi.h nvmpi_create_decoder
++enabled nvmpi             && require_pkg_config nvmpi nvmpi nvmpi.h nvmpi_create_decoder
  
  
  if enabled gcrypt; then
 diff --git a/libavcodec/Makefile b/libavcodec/Makefile
-index 3cd73fb..c3ed5cc 100644
+index 33a280c..0631acd 100644
 --- a/libavcodec/Makefile
 +++ b/libavcodec/Makefile
-@@ -354,6 +354,8 @@ OBJS-$(CONFIG_H264_MMAL_DECODER)       += mmaldec.o
+@@ -378,6 +378,8 @@ OBJS-$(CONFIG_H264_MMAL_DECODER)       += mmaldec.o
  OBJS-$(CONFIG_H264_NVENC_ENCODER)      += nvenc_h264.o
  OBJS-$(CONFIG_NVENC_ENCODER)           += nvenc_h264.o
  OBJS-$(CONFIG_NVENC_H264_ENCODER)      += nvenc_h264.o
 +OBJS-$(CONFIG_H264_NVMPI_DECODER)      += nvmpi_dec.o
 +OBJS-$(CONFIG_H264_NVMPI_ENCODER)      += nvmpi_enc.o
  OBJS-$(CONFIG_H264_OMX_ENCODER)        += omx.o
- OBJS-$(CONFIG_H264_QSV_DECODER)        += qsvdec_h2645.o
+ OBJS-$(CONFIG_H264_QSV_DECODER)        += qsvdec.o
  OBJS-$(CONFIG_H264_QSV_ENCODER)        += qsvenc_h264.o
-@@ -379,6 +381,8 @@ OBJS-$(CONFIG_HEVC_QSV_ENCODER)        += qsvenc_hevc.o hevc_ps_enc.o       \
- OBJS-$(CONFIG_HEVC_RKMPP_DECODER)      += rkmppdec.o
+@@ -406,6 +408,8 @@ OBJS-$(CONFIG_HEVC_RKMPP_DECODER)      += rkmppdec.o
  OBJS-$(CONFIG_HEVC_VAAPI_ENCODER)      += vaapi_encode_h265.o h265_profile_level.o
  OBJS-$(CONFIG_HEVC_V4L2M2M_DECODER)    += v4l2_m2m_dec.o
+ OBJS-$(CONFIG_HEVC_V4L2M2M_ENCODER)    += v4l2_m2m_enc.o
 +OBJS-$(CONFIG_HEVC_NVMPI_DECODER)      += nvmpi_dec.o
 +OBJS-$(CONFIG_HEVC_NVMPI_ENCODER)      += nvmpi_enc.o
- OBJS-$(CONFIG_HEVC_V4L2M2M_ENCODER)    += v4l2_m2m_enc.o
  OBJS-$(CONFIG_HNM4_VIDEO_DECODER)      += hnm4video.o
  OBJS-$(CONFIG_HQ_HQA_DECODER)          += hq_hqa.o hq_hqadata.o hq_hqadsp.o \
-@@ -464,11 +468,13 @@ OBJS-$(CONFIG_MPEG2_QSV_ENCODER)       += qsvenc_mpeg2.o
+                                           canopus.o
+@@ -495,12 +499,14 @@ OBJS-$(CONFIG_MPEG2_QSV_ENCODER)       += qsvenc_mpeg2.o
  OBJS-$(CONFIG_MPEG2VIDEO_DECODER)      += mpeg12dec.o mpeg12.o mpeg12data.o
  OBJS-$(CONFIG_MPEG2VIDEO_ENCODER)      += mpeg12enc.o mpeg12.o
  OBJS-$(CONFIG_MPEG2_CUVID_DECODER)     += cuviddec.o
@@ -118,20 +119,21 @@ index 3cd73fb..c3ed5cc 100644
  OBJS-$(CONFIG_MPEG2_VAAPI_ENCODER)     += vaapi_encode_mpeg2.o
  OBJS-$(CONFIG_MPEG2_V4L2M2M_DECODER)   += v4l2_m2m_dec.o
  OBJS-$(CONFIG_MPEG4_DECODER)           += xvididct.o
+ OBJS-$(CONFIG_MPEG4_ENCODER)           += mpeg4videoenc.o
  OBJS-$(CONFIG_MPEG4_CUVID_DECODER)     += cuviddec.o
 +OBJS-$(CONFIG_MPEG4_NVMPI_DECODER)     += nvmpi_dec.o
  OBJS-$(CONFIG_MPEG4_MEDIACODEC_DECODER) += mediacodecdec.o
  OBJS-$(CONFIG_MPEG4_OMX_ENCODER)       += omx.o
  OBJS-$(CONFIG_MPEG4_V4L2M2M_DECODER)   += v4l2_m2m_dec.o
-@@ -669,6 +675,7 @@ OBJS-$(CONFIG_VP6_DECODER)             += vp6.o vp56.o vp56data.o \
+@@ -715,6 +721,7 @@ OBJS-$(CONFIG_VP6_DECODER)             += vp6.o vp56.o vp56data.o \
  OBJS-$(CONFIG_VP7_DECODER)             += vp8.o vp56rac.o
  OBJS-$(CONFIG_VP8_DECODER)             += vp8.o vp56rac.o
  OBJS-$(CONFIG_VP8_CUVID_DECODER)       += cuviddec.o
 +OBJS-$(CONFIG_VP8_NVMPI_DECODER)       += nvmpi_dec.o
  OBJS-$(CONFIG_VP8_MEDIACODEC_DECODER)  += mediacodecdec.o
- OBJS-$(CONFIG_VP8_QSV_DECODER)         += qsvdec_other.o
+ OBJS-$(CONFIG_VP8_QSV_DECODER)         += qsvdec.o
  OBJS-$(CONFIG_VP8_RKMPP_DECODER)       += rkmppdec.o
-@@ -679,6 +686,7 @@ OBJS-$(CONFIG_VP9_DECODER)             += vp9.o vp9data.o vp9dsp.o vp9lpf.o vp9r
+@@ -725,6 +732,7 @@ OBJS-$(CONFIG_VP9_DECODER)             += vp9.o vp9data.o vp9dsp.o vp9lpf.o vp9r
                                            vp9block.o vp9prob.o vp9mvs.o vp56rac.o \
                                            vp9dsp_8bpp.o vp9dsp_10bpp.o vp9dsp_12bpp.o
  OBJS-$(CONFIG_VP9_CUVID_DECODER)       += cuviddec.o
@@ -140,10 +142,10 @@ index 3cd73fb..c3ed5cc 100644
  OBJS-$(CONFIG_VP9_RKMPP_DECODER)       += rkmppdec.o
  OBJS-$(CONFIG_VP9_VAAPI_ENCODER)       += vaapi_encode_vp9.o
 diff --git a/libavcodec/allcodecs.c b/libavcodec/allcodecs.c
-index d2f9a39..04dc62b 100644
+index 2e9a358..f75ebca 100644
 --- a/libavcodec/allcodecs.c
 +++ b/libavcodec/allcodecs.c
-@@ -143,11 +143,15 @@ extern AVCodec ff_h264_mediacodec_decoder;
+@@ -148,11 +148,15 @@ extern AVCodec ff_h264_mediacodec_decoder;
  extern AVCodec ff_h264_mmal_decoder;
  extern AVCodec ff_h264_qsv_decoder;
  extern AVCodec ff_h264_rkmpp_decoder;
@@ -159,8 +161,8 @@ index d2f9a39..04dc62b 100644
  extern AVCodec ff_hevc_v4l2m2m_decoder;
  extern AVCodec ff_hnm4_video_decoder;
  extern AVCodec ff_hq_hqa_decoder;
-@@ -766,18 +770,22 @@ extern AVCodec ff_mjpeg_qsv_encoder;
- extern AVCodec ff_mjpeg_vaapi_encoder;
+@@ -818,19 +822,23 @@ extern AVCodec ff_mjpeg_vaapi_encoder;
+ extern AVCodec ff_mp3_mf_encoder;
  extern AVCodec ff_mpeg1_cuvid_decoder;
  extern AVCodec ff_mpeg2_cuvid_decoder;
 +extern AVCodec ff_mpeg2_nvmpi_decoder;
@@ -169,6 +171,7 @@ index d2f9a39..04dc62b 100644
  extern AVCodec ff_mpeg4_cuvid_decoder;
 +extern AVCodec ff_mpeg4_nvmpi_decoder;
  extern AVCodec ff_mpeg4_mediacodec_decoder;
+ extern AVCodec ff_mpeg4_omx_encoder;
  extern AVCodec ff_mpeg4_v4l2m2m_encoder;
  extern AVCodec ff_vc1_cuvid_decoder;
  extern AVCodec ff_vp8_cuvid_decoder;
@@ -180,6 +183,7 @@ index d2f9a39..04dc62b 100644
  extern AVCodec ff_vp9_cuvid_decoder;
 +extern AVCodec ff_vp9_nvmpi_decoder;
  extern AVCodec ff_vp9_mediacodec_decoder;
+ extern AVCodec ff_vp9_qsv_decoder;
  extern AVCodec ff_vp9_vaapi_encoder;
  
 diff --git a/libavcodec/nvmpi_dec.c b/libavcodec/nvmpi_dec.c


### PR DESCRIPTION
This PR ports the patch file to match ffmpeg 4.4, the latest ffmpeg release at the time of writing.

I haven't tested all of it, but it compiles fine, and h264_nvmpi decoding and encoding works.